### PR TITLE
Remove namespace from rendered page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/at/pollux/thymeleaf/shiro/dialect/ShiroDialect.java
+++ b/src/main/java/at/pollux/thymeleaf/shiro/dialect/ShiroDialect.java
@@ -5,6 +5,8 @@ import at.pollux.thymeleaf.shiro.processor.element.*;
 import org.thymeleaf.dialect.AbstractProcessorDialect;
 import org.thymeleaf.processor.IProcessor;
 import org.thymeleaf.standard.StandardDialect;
+import org.thymeleaf.standard.processor.StandardXmlNsTagProcessor;
+import org.thymeleaf.templatemode.TemplateMode;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -62,6 +64,9 @@ public class ShiroDialect extends AbstractProcessorDialect {
 
         processors.add(new UserAttrProcessor(dialectPrefix));
         processors.add(new UserElementProcessor(dialectPrefix));
+
+		// Remove the xmlns:prefix attributes we might add for IDE validation but should not be exposed in the web browsers.
+		processors.add(new StandardXmlNsTagProcessor(TemplateMode.HTML, dialectPrefix));
 
         return processors;
     }


### PR DESCRIPTION
I really think that the **xmlns:shiro** namespace should not be exposed in the rendered HTML that is sent to the web browser. It is good practice to not let anyone know that we are using Shiro in the backend.

E.g. this is what you currently see in the web browser when viewing the source of the web page and using the xmlns:shiro to validate the code in the IDE:
`<html xmlns:shiro="http://shiro.apache.org/tags">`

It was a simple fix to remove the namespace, and it looks very neat.

Note that I unfortunately also needed to change the source and target version to 1.6 as the compiler complained about a too old version when building the project. So maybe you would want to update the minor version of the release when you pull in this request.

I hope you like my changes!